### PR TITLE
List cli as a vendor binary

### DIFF
--- a/cli/css_optimizer.php
+++ b/cli/css_optimizer.php
@@ -5,7 +5,12 @@
 // Based on leafo/lessphp cli utility
 
 error_reporting(E_ALL);
-require dirname(__FILE__) . '/../vendor/autoload.php';
+
+if (file_exists(dirname(__FILE__) . '/../../../autoload.php')) {
+    require dirname(__FILE__) . '/../../../autoload.php';
+} else {
+    require dirname(__FILE__) . '/../vendor/autoload.php';
+}
 
 $exe = array_shift($argv); // remove filename
 

--- a/composer.json
+++ b/composer.json
@@ -13,5 +13,6 @@
     "autoload": {
         "classmap": ["src/"]
     },
-    "keywords": ["css"]
+    "keywords": ["css"],
+    "bin": ["cli/css_optimizer.php"]
 }


### PR DESCRIPTION
When I installed this package from Packagist by Composer and run `cli/css_optimizer.php`, an error has occurred on line 8 because `autoload.php` can not be found.
I list `cli/css_optimizer.php` as a vendor binary in `composer.json`, and add require to `autoload.php` in `cli/css_optimizer.php` for when it is installed by Composer.
